### PR TITLE
middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,120 @@
+const {createSocket} = require('dgram')
+const parseurl = require('parseurl')
+const {toBuffer} = require('base64url')
+const {decode} = require('dns-packet')
+
+const {
+  BadRequest,
+  MethodNotAllowed,
+  PayloadTooLarge,
+  InternalServerError,
+  BadGateway,
+  GatewayTimeout,
+  HTTPVersionNotSupported
+} = require('http-errors')
+
+const {
+  constants: {
+    HTTP2_HEADER_ACCEPT,
+    HTTP2_HEADER_CACHE_CONTROL,
+    HTTP2_HEADER_CONTENT_LENGTH,
+    HTTP2_HEADER_CONTENT_TYPE,
+    HTTP2_METHOD_GET,
+    HTTP2_METHOD_POST
+  }
+} = require('http2')
+
+const dohMediaType = 'application/dns-message'
+const dohMaximumMessageLength = 65535
+const dohMinimumHttpVersionMajor = 2
+
+function smallestTtl (min, {ttl}) {
+  return ttl < min ? ttl : min
+}
+
+module.exports.playdoh =
+function playdoh ({
+  protocol = 'udp4', // or 'udp6'
+  localAddress = 'localhost', // Set empty string for 0.0.0.0 or ::0
+  resolverAddress = '', // Defaults to 127.0.0.1 or ::1
+  resolverPort = 53,
+  timeout = 10000
+} = {}) {
+  return async function playdoh (request, response, next) {
+    if (request.headers[HTTP2_HEADER_ACCEPT] !== dohMediaType) {
+      return next()
+    }
+    if (request.httpVersionMajor < dohMinimumHttpVersionMajor) {
+      return next(new HTTPVersionNotSupported())
+    }
+
+    const dnsMessage = []
+    switch (request.method) {
+      case HTTP2_METHOD_GET:
+        const {query} = parseurl(request)
+        try {
+          const decoded = toBuffer(query.dns)
+        } catch (error) {
+          return next(new BadRequest())
+        }
+        if (decoded.length > dohMaximumMessageLength) {
+          return next(new PayloadTooLarge())
+        }
+        dnsMessage.push(decoded)
+        break
+      case HTTP2_METHOD_POST:
+        let totalLength = 0
+        for await (const chunk of request) {
+          totalLength += chunk.length
+          if (totalLength > dohMaximumMessageLength) {
+            return next(new PayloadTooLarge())
+          }
+          dnsMessage.push(chunk)
+        }
+        break
+      default:
+        return next(new MethodNotAllowed())
+    }
+
+    let socket
+    try {
+      socket = createSocket(protocol)
+      socket.bind(localAddress)
+    } catch (error) {
+      return next(new InternalServerError())
+    }
+
+    socket.once('error', (error) => {
+      next(new BadGateway())
+    })
+
+    socket.once('listening', () => {
+      const timer = setTimeout(() => {
+        socket.close()
+        next(new GatewayTimeout())
+      }, timeout)
+      socket.once('close', () => clearTimeout(timer))
+      socket.send(dnsMessage, resolverPort, resolverAddress)
+      dnsMessage.length = 0
+    })
+
+    socket.on('message', (message, {size, port, address}) => {
+      if (address === resolverAddress && port === resolverPort) {
+        let answers
+        try {
+          ({answers} = decode(message))
+        } catch (error) {
+          return next(new BadGateway())
+        }
+        const ttl = answers.reduce(smallestTtl, Infinity)
+        if (Number.isFinite(ttl)) {
+          response.setHeader(HTTP2_HEADER_CACHE_CONTROL, `max-age=${ttl}`)
+        }
+        response.setHeader(HTTP2_HEADER_CONTENT_LENGTH, size)
+        response.setHeader(HTTP2_HEADER_CONTENT_TYPE, dohMediaType)
+        response.end(message)
+        socket.close()
+      }
+    })
+  }
+}

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,0 +1,60 @@
+const test = require('blue-tape')
+const {playdoh} = require('../middleware')
+const {promisify} = require('util')
+const connect = require('connect')
+const http2 = require('http2')
+const dnsPacket = require('dns-packet')
+
+test('Middleware', async (t) => {
+  const options = {
+    protocol: 'udp4',
+    localAddress: '0.0.0.0',
+    resolverAddress: '8.8.8.8',
+    resolverPort: 53,
+    timeout: 5000
+  }
+  const middleware = playdoh(options)
+
+  const app = connect()
+  app.use(middleware)
+  const server = http2.createServer(app)
+  await promisify(server.listen).call(server)
+
+  const session = http2.connect(
+    `http://localhost:${server.address().port}`
+  )
+  const request = session.request({
+    ':method': 'POST',
+    ':path': '/',
+    'accept': 'application/dns-message'
+  })
+  const packet = dnsPacket.encode({
+    type: 'query',
+    id: 0,
+    flags: dnsPacket.RECURSION_DESIRED,
+    questions: [{
+      type: 'A',
+      class: 'IN',
+      name: 'www.example.com'
+    }]
+  })
+  request.end(packet)
+  request.on('response', async (headers) => {
+    t.is(headers['content-type'], 'application/dns-message')
+    t.is(headers[':status'], 200)
+
+    const chunks = []
+    for await (const chunk of request) {
+      chunks.push(chunk)
+    }
+    const body = Buffer.concat(chunks)
+    const response = dnsPacket.decode(body)
+
+    t.is(response.type, 'response')
+    t.is(response.answers.length, 1)
+    t.is(headers['cache-control'], `max-age=${response.answers[0].ttl}`)
+
+    await promisify(session.close).call(session)
+    await promisify(server.close).call(server)
+  })
+})


### PR DESCRIPTION
Another little implementation of [DOH Draft 14](https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-14).

The middleware function signature is common in Node.js and supported by many servers like Connect, Express, or Fastify. The Commons Host edge server is based on Connect and should work fine.

To run the test:

```bash
tape test/middleware.js
```

Notable changes vs the Flow implementation:

- Accepts DOH requests on any URL. Up to the server to limit the middleware to a specific pathname or hostname/port.
- Creates a new UDP socket for each request. Fixes #2. Might rewrite this if it turns out to be a bottleneck. Basic benchmarks show 8000 socket binds takes 400ms on a 2.5 GHz i5 2011 CPU. Could change this to a UDP socket pool with incrementing ID to match DNS query/result.
- Timeout the UDP socket to avoid exhausting process file handles.
- Reject non-HTTP/2 clients.
- Sets `max-age` for caching to the lowest TTL of all answers.
- Checks against spoofed UDP message source.
- Options:
   ```js
   protocol = 'udp4', // or 'udp6'
   localAddress = 'localhost', // Set empty string for 0.0.0.0 or ::0
   resolverAddress = '', // Defaults to 127.0.0.1 or ::1
   resolverPort = 53,
   timeout = 10000
   ```