### PR TITLE
Fixes to the DOH middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,6 +1,6 @@
-const {createSocket} = require('dgram')
-const {toBuffer} = require('base64url')
-const {decode} = require('dns-packet')
+const { createSocket } = require('dgram')
+const { toBuffer } = require('base64url')
+const { decode } = require('dns-packet')
 
 const {
   BadRequest,
@@ -27,7 +27,7 @@ const dohMediaType = 'application/dns-message'
 const dohMaximumMessageLength = 65535
 const dohMinimumHttpVersionMajor = 2
 
-function smallestTtl (min, {ttl}) {
+function smallestTtl (min, { ttl }) {
   return ttl < min ? ttl : min
 }
 
@@ -50,7 +50,7 @@ function playdoh ({
     const dnsMessage = []
     switch (request.method) {
       case HTTP2_METHOD_GET:
-        const {url} = request
+        const { url } = request
         const dns = new URLSearchParams(url.substr(url.indexOf('?'))).get('dns')
         if (!dns) {
           return next(new BadRequest())
@@ -88,9 +88,7 @@ function playdoh ({
       return next(new InternalServerError())
     }
 
-    socket.once('error', (error) => {
-      next(new BadGateway())
-    })
+    socket.once('error', () => next(new BadGateway()))
 
     socket.once('listening', () => {
       const timer = setTimeout(() => {
@@ -102,12 +100,12 @@ function playdoh ({
       dnsMessage.length = 0
     })
 
-    socket.on('message', (message, {size, port, address}) => {
+    socket.on('message', (message, { size, port, address }) => {
       if (address === resolverAddress && port === resolverPort) {
         if (request.method === HTTP2_METHOD_GET) {
           let answers
           try {
-            ({answers} = decode(message))
+            ({ answers } = decode(message))
           } catch (error) {
             return next(new BadGateway())
           }

--- a/test/helpers/eventToPromise.js
+++ b/test/helpers/eventToPromise.js
@@ -1,0 +1,16 @@
+function eventToPromise (emitter, success, failure = 'error') {
+  return new Promise((resolve, reject) => {
+    function onSuccess (value) {
+      emitter.off(failure, onFailure)
+      resolve(value)
+    }
+    function onFailure (error) {
+      emitter.off(success, onSuccess)
+      reject(error)
+    }
+    emitter.once(success, onSuccess)
+    emitter.once(failure, onFailure)
+  })
+}
+
+module.exports.eventToPromise = eventToPromise

--- a/test/helpers/fetch.js
+++ b/test/helpers/fetch.js
@@ -1,0 +1,30 @@
+const http2 = require('http2')
+const {promisify} = require('util')
+const {eventToPromise} = require('./eventToPromise')
+
+async function fetch (url, options) {
+  const {origin, pathname, search} = new URL(url)
+  const session = http2.connect(origin)
+  const reqHeaders = {
+    ...options.headers,
+    ...{':path': pathname + search}
+  }
+  const request = session.request(reqHeaders)
+  request.end(options.body)
+  const headers = await eventToPromise(request, 'response')
+  const chunks = []
+  for await (const chunk of request) {
+    chunks.push(chunk)
+  }
+  await promisify(session.close).call(session)
+  const body = Buffer.concat(chunks)
+  chunks.length = 0
+  return {
+    get headers () { return new Map(Object.entries(headers)) },
+    async buffer () { return body },
+    async text () { return body.toString() },
+    async json () { return JSON.parse(body.toString()) }
+  }
+}
+
+module.exports.fetch = fetch

--- a/test/helpers/fetch.js
+++ b/test/helpers/fetch.js
@@ -1,13 +1,13 @@
 const http2 = require('http2')
-const {promisify} = require('util')
-const {eventToPromise} = require('./eventToPromise')
+const { promisify } = require('util')
+const { eventToPromise } = require('./eventToPromise')
 
 async function fetch (url, options) {
-  const {origin, pathname, search} = new URL(url)
+  const { origin, pathname, search } = new URL(url)
   const session = http2.connect(origin)
   const reqHeaders = {
     ...options.headers,
-    ...{':path': pathname + search}
+    ...{ ':path': pathname + search }
   }
   const request = session.request(reqHeaders)
   request.end(options.body)

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -1,11 +1,11 @@
 const test = require('blue-tape')
-const {playdoh} = require('../middleware')
-const {promisify} = require('util')
+const { playdoh } = require('../middleware')
+const { promisify } = require('util')
 const connect = require('connect')
 const http2 = require('http2')
 const dnsPacket = require('dns-packet')
-const {fetch} = require('./helpers/fetch')
-const {encode} = require('base64url')
+const { fetch } = require('./helpers/fetch')
+const { encode } = require('base64url')
 
 const dnsPacketQuery = dnsPacket.encode({
   type: 'query',
@@ -34,7 +34,7 @@ test('Start server with DOH middleware', async (t) => {
   app.use(middleware)
   server = http2.createServer(app)
   await promisify(server.listen).call(server)
-  const {port} = server.address()
+  const { port } = server.address()
   baseUrl = `http://localhost:${port}`
 })
 


### PR DESCRIPTION
feat: only set cache-control for GET (see note below)
fix: correctly parse query string for dns parameter
test: GET unit test
refactor: fetch helper to simplify test cases

Draft 14 section 5.1. Cache Interaction

As a result, DoH servers need to carefully consider the HTTP caching
metadata they send in response to GET requests (responses to POST
requests are not cacheable unless specific response header fields are
sent; this is not widely implemented, and not advised for DoH).